### PR TITLE
Allow to override the repl start function

### DIFF
--- a/examples/replpad.js
+++ b/examples/replpad.js
@@ -1,0 +1,13 @@
+var replpad;
+
+try {
+  replpad = require('replpad');
+} catch (e) {
+  console.error('For this example you need to `npm install replpad` first.')
+  process.exit(1)
+}
+
+var replify = require('../')
+  , app = require('http').createServer()
+
+replify({ name: 'replpad-101', startRepl: replpad }, app)

--- a/replify.js
+++ b/replify.js
@@ -39,7 +39,7 @@ module.exports = function replify (options, app, ctx) {
         socket.columns = 132 // Set screen width for autocomplete. You can modify this locally in your repl.
 
         if (fs.exists) { // if `fs.exists` exists, then it's node v0.8
-          r = repl.start(repl_opt)
+          r = options.startRepl ? options.startRepl(repl_opt) : repl.start(repl_opt)
           r.on('exit', function () {
             socket.end()
           })


### PR DESCRIPTION
For node > 0.6 you can now override the repl start function which enables using a non-default repl.

As an example you can now use replpad and get all its extra [features](https://github.com/thlorenz/replpad#features) while debugging your server using `repl-client` as outlined in `examples/replpad.js` and shown below:

![screen shot 2013-08-10 at 1 04 20 pm](https://f.cloud.github.com/assets/192891/942917/3d0d7c68-01e0-11e3-90c7-e33a46ee3852.png)
