### PR TITLE
fixing 'ctx not defined' bug

### DIFF
--- a/replify.js
+++ b/replify.js
@@ -89,7 +89,7 @@ module.exports = function replify (options, app, contexts) {
             // don't pave over existing contexts
             logger.warn('unable to register context: ' + key)
           } else {
-            rep.context[key] = ctx[key]
+            rep.context[key] = options.contexts[key]
           }
         })
       })


### PR DESCRIPTION
replify was referring to non-existing `ctx` which caused crash whenever I passed extra context besides app.
