### PR TITLE
fixed reference error to nonexistent replDir

### DIFF
--- a/replify.js
+++ b/replify.js
@@ -92,7 +92,7 @@ module.exports = function replify (options, app, contexts) {
 
   fs.mkdir(options.path, function (err) {
     if (err && err.code !== 'EEXIST') {
-      return logger.error('error making repl directory: ' + replDir, err)
+      return logger.error('error making repl directory: ' + options.path, err)
     }
 
     fs.unlink(options.replPath, function () {


### PR DESCRIPTION
Fix for (part of) https://github.com/dshaw/replify/issues/10

I'm not working on replify at the moment and have only the vaguest idea of what it does.

I don't even a local copy, but this seems like a fairly straightforward fix.
