### PR TITLE
EventEmitter & Replify Class

### DIFF
--- a/replify.js
+++ b/replify.js
@@ -8,15 +8,21 @@
  * Module dependencies
  */
 
-var fs = require('fs')
-  , net = require('net')
-  , repl = require('repl')
+var fs = require('fs');
+var net = require('net');
+var repl = require('repl');
+var util = require('util');
 
-/**
- * Exports - replify
- */
+var EventEmitter = require('events').EventEmitter;
 
-module.exports = function replify (options, app, contexts) {
+function Replify() {
+
+}
+
+util.inherits( Replify , EventEmitter );
+
+Replify.prototype.init = function init(options, app, contexts) {
+  var self = this;
   options = (options && options.name) ? options : { name: options }
 
   options.app                         || (options.app = app)
@@ -33,6 +39,11 @@ module.exports = function replify (options, app, contexts) {
 
   var logger = options.logger
     , replServer = net.createServer()
+
+  replServer.on('listening', function onListening() {
+    console.log('replserver listening!');
+    self.emit('ready');
+  });
 
   replServer.on('connection', function onRequest(socket) {
     var rep = null
@@ -104,3 +115,9 @@ module.exports = function replify (options, app, contexts) {
 
   return replServer
 }
+
+/**
+ * Exports - replify
+ */
+
+module.exports = Replify;

--- a/replify.js
+++ b/replify.js
@@ -52,7 +52,6 @@ Replify.prototype.init = function init(options, app, contexts) {
     , replServer = net.createServer()
 
   replServer.on('listening', function onListening() {
-    console.log('replserver listening!');
     self.emit('ready');
   });
 

--- a/replify.js
+++ b/replify.js
@@ -10,6 +10,7 @@
 
 var fs = require('fs');
 var net = require('net');
+var path = require('path');
 var repl = require('repl');
 var util = require('util');
 

--- a/test/replify.test.js
+++ b/test/replify.test.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
   , http = require('http')
   , net = require('net')
-  , replify = require('../')
+  , Replify = require('../')
   , tap = require('tap')
   , test = tap.test
 
@@ -57,7 +57,8 @@ test('replify', function (t) {
     }, 250)
   })
 
-  replify('net-test', app)
+  var replify = new Replify();
+  replify.init('net-test', app)
 })
 
 test('replify has app in context', function (t) {
@@ -76,7 +77,9 @@ test('replify has app in context', function (t) {
       })
     }, 250)
   })
-  replify({ name: 'net-test', useColors: false }, app)
+  
+  var replify = new Replify();
+  replify.init({ name: 'net-test', useColors: false }, app);
 })
 
 test('replify accepts custom context as last param', function (t) {
@@ -95,7 +98,9 @@ test('replify accepts custom context as last param', function (t) {
       })
     }, 250)
   })
-  replify({ name: 'net-test', usecolors: false }, app, { node: 'up' })
+  
+  var replify = new Replify();
+  replify.init({ name: 'net-test', usecolors: false }, app, { node: 'up' })
 })
 
 test('replify accepts custom context as options property', function (t) {
@@ -114,14 +119,16 @@ test('replify accepts custom context as options property', function (t) {
       })
     }, 250)
   })
-  replify({ name: 'net-test', usecolors: false, contexts: { node: 'up' } }, app)
+  var replify = new Replify();
+  replify.init({ name: 'net-test', usecolors: false, contexts: { node: 'up' } }, app)
 })
 
 test('replify exposes net server', function (t) {
 
   var TcpServer = net.Server
     , app = http.createServer()
-    , replServer = replify({ name: 'net-test', usecolors: false }, app)
+    , replify = new Replify()
+    , replServer = replify.init({ name: 'net-test', usecolors: false }, app)
 
   t.on('end', app.close.bind(app))
 


### PR DESCRIPTION
This converts replify into a Class, which can be constructed with `myInstance.init( ... )`, where init accepts all parameters the previous constructor did.

```
var replify = require('replify');
replify('realtime-101', app);
```

becomes

```
var Replify = require('replify');
var replify = new Replify();
replify.init('realtime-101', app);
```
